### PR TITLE
Delete tungstenfabric-preview/intent-service from project list.

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -165,7 +165,7 @@
           - tungstenfabric-preview/vijava
           - tungstenfabric/docs
           - tungstenfabric-preview/test-runner
-          - tungstenfabric-preview/intent-service
+            # - tungstenfabric-preview/intent-service
           - tungstenfabric-preview/windows-test
           - tungstenfabric-preview/windows-ci-infra
           - tungstenfabric-preview/vcenter-fabric-manager


### PR DESCRIPTION
zuul.configloader.ConfigurationSyntaxError: Zuul encountered a syntax error while parsing its configuration in the
repo tungstenfabric-preview/intent-service on branch master.  The
error was:

  The project template "build-container-go" was not found.

The error appears in the following project stanza:

  project:
      name: tungstenfabric-preview/intent-service
      templates:
        - build-container-go